### PR TITLE
Remove the awesome_print require

### DIFF
--- a/lib/shipstation_ruby.rb
+++ b/lib/shipstation_ruby.rb
@@ -1,6 +1,5 @@
 require "rash"
 require "ruby_odata"
-require "awesome_print"
 
 require "shipstation_ruby/client"
 require "shipstation_ruby/collection"


### PR DESCRIPTION
Awesome Print was not included in the gemspec as a dependency, which
would cause `LoadError`s when requiring shipstation.

I didn't see any calls to `ap` in the code, so I just removed that
require.
